### PR TITLE
Added TextMate 2 gutterSettings to tmTheme.

### DIFF
--- a/Toy Chest.tmbundle/Themes/Toy Chest.tmTheme
+++ b/Toy Chest.tmbundle/Themes/Toy Chest.tmTheme
@@ -4,6 +4,33 @@
 <dict>
 	<key>author</key>
 	<string>Jackson Gariety</string>
+	<key>gutterSettings</key>
+	<dict>
+		<key>background</key>
+		<string>#f5f5f5</string>
+		<key>divider</key>
+		<string>#9F9F9F</string>
+		<key>foreground</key>
+		<string>#a0a0a0</string>
+		<key>icons</key>
+		<string>#666666</string>
+		<key>iconsHover</key>
+		<string>#666666</string>
+		<key>iconsPressed</key>
+		<string>#333333</string>
+		<key>selectionBackground</key>
+		<string>#ffffff</string>
+		<key>selectionBorder</key>
+		<string>#D8D8D8</string>
+		<key>selectionForeground</key>
+		<string>#4b4b4b</string>
+		<key>selectionIcons</key>
+		<string>#2D85C5</string>
+		<key>selectionIconsHover</key>
+		<string>#34D58E</string>
+		<key>selectionIconsPressed</key>
+		<string>#EA7F2A</string>
+	</dict>
 	<key>name</key>
 	<string>Toy Chest</string>
 	<key>semanticClass</key>
@@ -22,9 +49,9 @@
 				<key>invisibles</key>
 				<string>#3a526b</string>
 				<key>lineHighlight</key>
-				<string>#1a2631</string>
+				<string>#293D4D</string>
 				<key>selection</key>
-				<string>#74358d</string>
+				<string>#0053AA</string>
 			</dict>
 		</dict>
 		<dict>
@@ -183,8 +210,7 @@
 			<key>name</key>
 			<string>-----------------------------------</string>
 			<key>settings</key>
-			<dict>
-			</dict>
+			<dict/>
 		</dict>
 		<dict>
 			<key>name</key>
@@ -262,7 +288,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>c C&#x2f;C++ Preprocessor Line</string>
+			<string>c C/C++ Preprocessor Line</string>
 			<key>scope</key>
 			<string>meta.preprocessor.c</string>
 			<key>settings</key>
@@ -273,7 +299,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>c C&#x2f;C++ Preprocessor Directive</string>
+			<string>c C/C++ Preprocessor Directive</string>
 			<key>scope</key>
 			<string>meta.preprocessor.c keyword</string>
 			<key>settings</key>
@@ -284,7 +310,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>✘ Doctype&#x2f;XML Processing</string>
+			<string>✘ Doctype/XML Processing</string>
 			<key>scope</key>
 			<string>meta.tag.sgml.doctype, meta.tag.sgml.doctype entity, meta.tag.sgml.doctype string, meta.tag.preprocessor.xml, meta.tag.preprocessor.xml entity, meta.tag.preprocessor.xml string</string>
 			<key>settings</key>


### PR DESCRIPTION
TM2 now allows you to style the gutter, which contains line numbers, foldings, and bookmarks. Since we did not explicitly set those attributes, it did not have appropriate styling. 

Signed-off-by: Jeremy Pinnix jpinnix@pixelgrazer.com
